### PR TITLE
refactor ProjectId

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Generate
+    name: Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,10 +103,7 @@ fn parse_args(
 
     let mut project_ids: Vec<ProjectId> = Vec::new();
     for arg in &args[required_args..] {
-        match ProjectId::from(arg) {
-            Some(project_id) => project_ids.push(project_id),
-            None => return error!(format!("Unknown project '{arg}'")),
-        };
+        project_ids.push(ProjectId::from(arg)?);
     }
     Ok((android_dir, ndk_dir, project_ids))
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -29,17 +29,17 @@ const SPIRV_HEADERS_NAME: &str = "SPIRV-Headers";
 const SPIRV_TOOLS_NAME: &str = "SPIRV-Tools";
 
 impl ProjectId {
-    pub fn from(str: &str) -> Option<ProjectId> {
-        match str {
-            CLVK_NAME => Some(ProjectId::Clvk),
-            CLSPV_NAME => Some(ProjectId::Clspv),
-            LLVM_PROJECT_NAME => Some(ProjectId::LlvmProject),
-            SPIRV_HEADERS_NAME => Some(ProjectId::SpirvHeaders),
-            SPIRV_TOOLS_NAME => Some(ProjectId::SpirvTools),
-            _ => None,
-        }
+    pub fn from(project: &str) -> Result<ProjectId, String> {
+        Ok(match project {
+            CLVK_NAME => ProjectId::Clvk,
+            CLSPV_NAME => ProjectId::Clspv,
+            LLVM_PROJECT_NAME => ProjectId::LlvmProject,
+            SPIRV_HEADERS_NAME => ProjectId::SpirvHeaders,
+            SPIRV_TOOLS_NAME => ProjectId::SpirvTools,
+            _ => return error!(format!("Unknown project '{project}'")),
+        })
     }
-    pub const fn str(&self) -> &'static str {
+    pub const fn str(self) -> &'static str {
         match self {
             ProjectId::Clvk => CLVK_NAME,
             ProjectId::Clspv => CLSPV_NAME,

--- a/src/project/clvk.rs
+++ b/src/project/clvk.rs
@@ -93,11 +93,9 @@ impl Project for Clvk {
     fn get_gen_deps(&self, project: ProjectId) -> GenDepsMap {
         let mut deps: GenDepsMap = HashMap::new();
         let mut libs: HashSet<String> = HashSet::new();
+        let prefix = add_slash_suffix(project.str());
         for library in &self.generated_libraries {
-            if let Some(lib) = self
-                .get_library_name(library)
-                .strip_prefix(&add_slash_suffix(project.str()))
-            {
+            if let Some(lib) = self.get_library_name(library).strip_prefix(&prefix) {
                 libs.insert(lib.to_string());
             }
         }


### PR DESCRIPTION
ProjectId::str now consume itself
ProjectId::from returns a Result

Also rename presubmit job from Generate to Tests