### PR TITLE
refactor generate_package to return a String instead of a SoongPackage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,6 @@ fn generate_project(
     ctx: &Context,
 ) -> Result<(), String> {
     let project_name = project.get_name();
-    let android_path = project.get_android_path(ctx);
-    let test_path = project.get_test_path(ctx);
     let project_ctx = if !is_dependency {
         print_info!("Generating '{project_name}'");
         ctx.clone()
@@ -40,12 +38,12 @@ fn generate_project(
         print_debug!("Writing soong file...");
 
         const ANDROID_BP: &str = "Android.bp";
-        let file_path = test_path.join(ANDROID_BP);
-        write_file(file_path.as_path(), &package.print())?;
+        let file_path = project.get_test_path(ctx).join(ANDROID_BP);
+        write_file(file_path.as_path(), &package)?;
         print_verbose!("{file_path:#?} created");
 
         if ctx.copy_to_aosp {
-            let copy_dst = android_path.join(ANDROID_BP);
+            let copy_dst = project.get_android_path(ctx).join(ANDROID_BP);
             copy_file(&file_path, &copy_dst)?;
             print_verbose!("{file_path:#?} copied to {copy_dst:#?}");
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -190,7 +190,7 @@ where
     parse_ninja_file(dir_path.join(split.nth(1).unwrap()), dir_path)
 }
 
-fn parse_ninja_file<'a, T>(
+fn parse_ninja_file<T>(
     file_path: PathBuf,
     build_path: &Path,
 ) -> Result<(Vec<T>, NinjaRulesMap), String>

--- a/src/project.rs
+++ b/src/project.rs
@@ -98,7 +98,7 @@ pub trait Project {
         &mut self,
         ctx: &Context,
         projects_map: &ProjectsMap,
-    ) -> Result<SoongPackage, String>;
+    ) -> Result<String, String>;
     // DEPENDENCIES FUNCTIONS
     fn get_deps_prefix(&self) -> Vec<(PathBuf, Dep)> {
         Vec::new()

--- a/src/project/angle.rs
+++ b/src/project/angle.rs
@@ -50,7 +50,7 @@ impl Project for Angle {
         &mut self,
         ctx: &Context,
         _projects_map: &ProjectsMap,
-    ) -> Result<SoongPackage, String> {
+    ) -> Result<String, String> {
         self.src_path = if let Ok(path) = std::env::var("N2S_ANGLE_PATH") {
             PathBuf::from(path)
         } else {
@@ -70,8 +70,12 @@ impl Project for Angle {
                 ]
             )?;
         }
-        let targets = parse_build_ninja::<GnNinjaTarget>(&self.build_path)?;
 
+        let targets = parse_build_ninja::<GnNinjaTarget>(&self.build_path)?;
+        let targets_to_generate = TARGETS
+            .into_iter()
+            .map(|target| PathBuf::from(target))
+            .collect();
         let mut package = SoongPackage::new(
             &self.src_path,
             &self.ndk_path,
@@ -81,13 +85,9 @@ impl Project for Angle {
             vec!["SPDX-license-identifier-Apache-2.0"],
             vec!["LICENSE"],
         );
-        let targets_to_generate = TARGETS
-            .into_iter()
-            .map(|target| PathBuf::from(target))
-            .collect();
         package.generate(targets_to_generate, targets, self)?;
 
-        Ok(package)
+        Ok(package.print())
     }
 
     fn get_target_name(&self, target: &Path) -> PathBuf {

--- a/src/project/clspv.rs
+++ b/src/project/clspv.rs
@@ -27,7 +27,7 @@ impl Project for Clspv {
         &mut self,
         ctx: &Context,
         projects_map: &ProjectsMap,
-    ) -> Result<SoongPackage, String> {
+    ) -> Result<String, String> {
         self.src_path = self.get_android_path(ctx);
         self.build_path = ctx.temp_path.join(self.get_name());
         self.ndk_path = get_ndk_path(&ctx.temp_path)?;
@@ -52,7 +52,6 @@ impl Project for Clspv {
         }
 
         let targets = parse_build_ninja::<CmakeNinjaTarget>(&self.build_path)?;
-
         let mut package = SoongPackage::new(
             &self.src_path,
             &self.ndk_path,
@@ -63,10 +62,9 @@ impl Project for Clspv {
             vec!["LICENSE"],
         );
         package.generate(Dep::ClspvTargets.get(projects_map)?, targets, self)?;
-
         self.gen_deps = package.get_gen_deps();
 
-        Ok(package)
+        Ok(package.print())
     }
 
     fn get_deps_prefix(&self) -> Vec<(PathBuf, Dep)> {

--- a/src/project/clvk.rs
+++ b/src/project/clvk.rs
@@ -25,7 +25,7 @@ impl Project for Clvk {
         &mut self,
         ctx: &Context,
         projects_map: &ProjectsMap,
-    ) -> Result<SoongPackage, String> {
+    ) -> Result<String, String> {
         self.src_path = self.get_android_path(ctx);
         self.build_path = ctx.temp_path.join(self.get_name());
         self.ndk_path = get_ndk_path(&ctx.temp_path)?;
@@ -50,7 +50,6 @@ impl Project for Clvk {
         }
 
         let targets = parse_build_ninja::<CmakeNinjaTarget>(&self.build_path)?;
-
         let mut package = SoongPackage::new(
             &self.src_path,
             &self.ndk_path,
@@ -61,9 +60,9 @@ impl Project for Clvk {
             vec!["LICENSE"],
         );
         package.generate(vec![PathBuf::from("libOpenCL.so")], targets, self)?;
-
         self.gen_libs = package.get_gen_libs();
-        Ok(package)
+
+        Ok(package.print())
     }
 
     fn get_deps(&self, dep: Dep) -> Vec<PathBuf> {

--- a/src/project/llvm_project.rs
+++ b/src/project/llvm_project.rs
@@ -26,7 +26,7 @@ impl Project for LlvmProject {
         &mut self,
         ctx: &Context,
         projects_map: &ProjectsMap,
-    ) -> Result<SoongPackage, String> {
+    ) -> Result<String, String> {
         self.src_path = self.get_android_path(ctx);
         self.build_path = ctx.temp_path.join(self.get_name());
         self.ndk_path = get_ndk_path(&ctx.temp_path)?;
@@ -59,7 +59,6 @@ impl Project for LlvmProject {
         }
 
         let targets = parse_build_ninja::<CmakeNinjaTarget>(&self.build_path)?;
-
         let mut package = SoongPackage::new(
             &self.src_path,
             &self.ndk_path,
@@ -89,7 +88,6 @@ impl Project for LlvmProject {
             "tools/clang/include/clang/Config/config.h",
         ];
         gen_deps.extend(missing_gen_deps.iter().map(|dep| PathBuf::from(dep)));
-
         package.filter_local_include_dirs(CMAKE_GENERATED, &gen_deps);
         common::copy_gen_deps(gen_deps, CMAKE_GENERATED, &self.build_path, ctx, self)?;
 
@@ -123,7 +121,7 @@ impl Project for LlvmProject {
             ));
         }
 
-        Ok(package)
+        Ok(package.print())
     }
 
     fn get_target_module(&self, _target: &Path, mut module: SoongModule) -> SoongModule {

--- a/src/project/mesa.rs
+++ b/src/project/mesa.rs
@@ -49,7 +49,7 @@ impl Project for Mesa {
         &mut self,
         ctx: &Context,
         _projects_map: &ProjectsMap,
-    ) -> Result<SoongPackage, String> {
+    ) -> Result<String, String> {
         self.src_path = if let Ok(path) = std::env::var("N2S_MESA_PATH") {
             PathBuf::from(path)
         } else {
@@ -116,7 +116,7 @@ impl Project for Mesa {
         package.filter_local_include_dirs(MESON_GENERATED, &gen_deps);
         common::copy_gen_deps(gen_deps, MESON_GENERATED, &self.build_path, ctx, self)?;
 
-        Ok(package)
+        Ok(package.print())
     }
 
     fn get_target_name(&self, target: &Path) -> PathBuf {

--- a/src/project/spirv_headers.rs
+++ b/src/project/spirv_headers.rs
@@ -4,9 +4,7 @@
 use super::*;
 
 #[derive(Default)]
-pub struct SpirvHeaders {
-    src_path: PathBuf,
-}
+pub struct SpirvHeaders();
 
 impl Project for SpirvHeaders {
     fn get_name(&self) -> &'static str {
@@ -22,10 +20,10 @@ impl Project for SpirvHeaders {
         &mut self,
         ctx: &Context,
         projects_map: &ProjectsMap,
-    ) -> Result<SoongPackage, String> {
-        self.src_path = self.get_android_path(ctx);
+    ) -> Result<String, String> {
+        let src_path = self.get_android_path(ctx);
         let mut package = SoongPackage::new(
-            &self.src_path,
+            &src_path,
             Path::new(""),
             Path::new(""),
             "//visibility:public",
@@ -33,7 +31,6 @@ impl Project for SpirvHeaders {
             vec!["SPDX-license-identifier-MIT"],
             vec!["LICENSE"],
         );
-
         package.add_module(SoongModule::new_cc_library_headers(
             CcLibraryHeaders::SpirvHeaders,
             vec![String::from("include")],
@@ -41,11 +38,11 @@ impl Project for SpirvHeaders {
 
         for file in Dep::SpirvHeaders.get(projects_map)? {
             package.add_module(SoongModule::new_copy_genrule(
-                Dep::SpirvHeaders.get_id(&file, &self.src_path, Path::new("")),
+                Dep::SpirvHeaders.get_id(&file, &src_path, Path::new("")),
                 &file,
             ));
         }
 
-        Ok(package)
+        Ok(package.print())
     }
 }

--- a/src/project/spirv_tools.rs
+++ b/src/project/spirv_tools.rs
@@ -26,7 +26,7 @@ impl Project for SpirvTools {
         &mut self,
         ctx: &Context,
         projects_map: &ProjectsMap,
-    ) -> Result<SoongPackage, String> {
+    ) -> Result<String, String> {
         self.src_path = self.get_android_path(ctx);
         self.build_path = ctx.temp_path.join(self.get_name());
         self.ndk_path = get_ndk_path(&ctx.temp_path)?;
@@ -48,7 +48,6 @@ impl Project for SpirvTools {
         }
 
         let targets = parse_build_ninja::<CmakeNinjaTarget>(&self.build_path)?;
-
         let mut package = SoongPackage::new(
             &self.src_path,
             &self.ndk_path,
@@ -63,10 +62,9 @@ impl Project for SpirvTools {
             CcLibraryHeaders::SpirvTools,
             vec![String::from("include")],
         ));
-
         self.gen_deps = package.get_gen_deps();
 
-        Ok(package)
+        Ok(package.print())
     }
 
     fn get_deps_prefix(&self) -> Vec<(PathBuf, Dep)> {


### PR DESCRIPTION
It prevents from having a project returning a SoongPackage having a reference on the project internal fields (src_path, build_path, etc)