### PR TITLE
add SoongModuleGenerator::filter_target

### DIFF
--- a/src/soong_module_generator.rs
+++ b/src/soong_module_generator.rs
@@ -56,6 +56,12 @@ where
         self.internals
     }
 
+    pub fn filter_target(&self, target: &T) -> bool {
+        let target_name = target.get_name();
+        debug_project!("filter_target({target_name:#?})");
+        self.project.filter_target(&target_name)
+    }
+
     fn replace_path(&self, iter: impl Iterator<Item = String>) -> Vec<String> {
         let iter = iter.map(|path| {
             path.replace(&path_to_string_with_separator(self.src_path), "")

--- a/src/soong_package.rs
+++ b/src/soong_package.rs
@@ -150,9 +150,7 @@ impl SoongPackage {
             project,
         );
         targets_map.traverse_from(targets_to_gen.get_targets(), |target| {
-            let target_name = target.get_name();
-            debug_project!("filter_target({target_name:#?})");
-            if !project.filter_target(&target_name) {
+            if !gen.filter_target(target) {
                 return Ok(false);
             }
             self.modules.push(match target.get_rule()? {


### PR DESCRIPTION
It allows to avoid keeping a ref on project in SoongPackage::generate while the ref has been pass through to SoongModuleGenerator.