### PR TITLE
Revert "remove std::mem::take to avoid a useless memzero (#143)"

### DIFF
--- a/src/project/clspv.rs
+++ b/src/project/clspv.rs
@@ -47,7 +47,7 @@ impl Project for Clspv {
             )?;
         }
 
-        let package = SoongPackage::new(
+        let mut package = SoongPackage::new(
             "//external/clvk",
             "clspv_license",
             &["SPDX-license-identifier-Apache-2.0"],

--- a/src/project/clvk.rs
+++ b/src/project/clvk.rs
@@ -43,7 +43,7 @@ impl Project for Clvk {
             )?;
         }
 
-        let package = SoongPackage::new(
+        let mut package = SoongPackage::new(
             "//visibility:public",
             "clvk_license",
             &["SPDX-license-identifier-Apache-2.0"],

--- a/src/project/spirv_tools.rs
+++ b/src/project/spirv_tools.rs
@@ -43,7 +43,7 @@ impl Project for SpirvTools {
             )?;
         }
 
-        let package = SoongPackage::new(
+        let mut package = SoongPackage::new(
             "//visibility:public",
             "SPIRV-Tools_license",
             &["SPDX-license-identifier-Apache-2.0"],

--- a/src/soong_package.rs
+++ b/src/soong_package.rs
@@ -112,18 +112,16 @@ impl SoongPackage {
         package
     }
 
-    pub fn get_gen_deps(&self) -> Vec<PathBuf> {
-        let mut gen_deps = self.internals.deps.clone();
-        gen_deps.sort_unstable();
-        gen_deps.dedup();
-        gen_deps
+    pub fn get_gen_deps(&mut self) -> Vec<PathBuf> {
+        self.internals.deps.sort_unstable();
+        self.internals.deps.dedup();
+        std::mem::take(&mut self.internals.deps)
     }
 
-    pub fn get_gen_libs(&self) -> Vec<PathBuf> {
-        let mut gen_libs = self.internals.libs.clone();
-        gen_libs.sort_unstable();
-        gen_libs.dedup();
-        gen_libs
+    pub fn get_gen_libs(&mut self) -> Vec<PathBuf> {
+        self.internals.libs.sort_unstable();
+        self.internals.libs.dedup();
+        std::mem::take(&mut self.internals.libs)
     }
 
     pub fn generate<T>(


### PR DESCRIPTION
This reverts commit abd6843015fe30a30d04cbff0ddb1bedcdebad19.