### PR TITLE
mesa: Build only on x86_64

### DIFF
--- a/src/project/mesa3d_desktop_intel.rs
+++ b/src/project/mesa3d_desktop_intel.rs
@@ -169,11 +169,12 @@ impl Project for Mesa3DDesktopIntel {
                 "header_libs",
                 SoongProp::VecStr(libs.into_iter().map(|lib| String::from(lib)).collect()),
             )
+            .add_prop("enabled", SoongProp::Bool(false))
             .add_prop(
                 "arch",
                 SoongNamedProp::new_prop(
-                    "x86",
-                    SoongNamedProp::new_prop("enabled", SoongProp::Bool(false)),
+                    "x86_64",
+                    SoongNamedProp::new_prop("enabled", SoongProp::Bool(true)),
                 ),
             )
     }

--- a/src/project/mesa3d_desktop_intel.rs
+++ b/src/project/mesa3d_desktop_intel.rs
@@ -85,37 +85,37 @@ impl Project for Mesa3DDesktopIntel {
             NinjaTargetsToGenMap::from(&[
                 NinjaTargetToGen(
                     "src/mapi/shared-glapi/libglapi.so.0.0.0",
-                    Some("libglapi_mesa3d_desktop_intel"),
+                    Some("mesa3d_desktop-intel_libglapi"),
                     Some("libglapi"),
                 ),
                 NinjaTargetToGen(
                     "src/gallium/targets/dri/libgallium_dri.so",
-                    Some("libgallium_dri_mesa3d_desktop_intel"),
+                    Some("mesa3d_desktop-intel_libgallium_dri"),
                     Some("libgallium_dri"),
                 ),
                 NinjaTargetToGen(
                     "src/egl/libEGL_mesa.so.1.0.0",
-                    Some("libEGL_mesa3d_desktop_intel"),
+                    Some("mesa3d_desktop-intel_libEGL_mesa"),
                     Some("libEGL_mesa"),
                 ),
                 NinjaTargetToGen(
                     "src/mapi/es2api/libGLESv2_mesa.so.2.0.0",
-                    Some("libGLESv2_mesa3d_desktop_intel"),
+                    Some("mesa3d_desktop-intel_libGLESv2_mesa"),
                     Some("libGLESv2_mesa"),
                 ),
                 NinjaTargetToGen(
                     "src/mapi/es1api/libGLESv1_CM_mesa.so.1.1.0",
-                    Some("libGLESv1_CM_mesa3d_desktop_intel"),
+                    Some("mesa3d_desktop-intel_libGLESv1_CM_mesa"),
                     Some("libGLESv1_CM_mesa"),
                 ),
                 NinjaTargetToGen(
                     "src/intel/vulkan/libvulkan_intel.so",
-                    Some("libvulkan_intel_mesa3d_desktop_intel"),
+                    Some("mesa3d_desktop-intel_libvulkan_intel"),
                     Some("vulkan.intel"),
                 ),
                 NinjaTargetToGen(
                     "src/tool/pps/pps-producer",
-                    Some("pps-producer_mesa3d_desktop_intel"),
+                    Some("mesa3d_desktop-intel_pps-producer"),
                     Some("pps-producer"),
                 ),
             ]),

--- a/tests/mesa3d/desktop-intel/Android.bp
+++ b/tests/mesa3d/desktop-intel/Android.bp
@@ -184,9 +184,10 @@ cc_binary {
         "src/tool/pps",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -201,9 +202,10 @@ cc_library_static {
         "-Wno-non-virtual-dtor",
     ],
     local_include_dirs: ["subprojects/perfetto"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -321,9 +323,10 @@ cc_library_static {
         "src",
         "src/util",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -529,9 +532,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -651,9 +655,10 @@ cc_library_static {
         "-Wno-non-virtual-dtor",
     ],
     local_include_dirs: ["src/util/blake3"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -779,9 +784,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -912,9 +918,10 @@ cc_library_static {
         "src/intel/perf",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -1037,9 +1044,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -1162,9 +1170,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -1295,9 +1304,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -1428,9 +1438,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -1560,9 +1571,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -1693,9 +1705,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -1826,9 +1839,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -1958,9 +1972,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -2091,9 +2106,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -2224,9 +2240,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -2357,9 +2374,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -2490,9 +2508,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -2623,9 +2642,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -2755,9 +2775,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -2888,9 +2909,10 @@ cc_library_static {
         "src/intel/isl",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -3017,9 +3039,10 @@ cc_library_static {
         "src/tool",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -3150,9 +3173,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -3296,9 +3320,10 @@ cc_library_static {
         "src/intel/genxml",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -3416,9 +3441,10 @@ cc_library_static {
         "src",
         "src/intel/common",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -3534,9 +3560,10 @@ cc_library_static {
         "src",
         "src/c11/impl",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -3682,9 +3709,10 @@ cc_library_shared {
         "src/mapi/shared-glapi",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -3812,9 +3840,10 @@ cc_library_shared {
         "src/mapi",
         "src/mapi/es2api",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -3942,9 +3971,10 @@ cc_library_shared {
         "src/mapi",
         "src/mapi/es1api",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -4149,9 +4179,10 @@ cc_library_shared {
         "src/vulkan/wsi",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -4286,9 +4317,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -4420,9 +4452,10 @@ cc_library_static {
         "src/vulkan/util",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -4571,9 +4604,10 @@ cc_library_static {
         "src/vulkan/util",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -4759,9 +4793,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -4891,9 +4926,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -5017,9 +5053,10 @@ cc_library_static {
         "src",
         "src/util/u_gralloc",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -5142,9 +5179,10 @@ cc_library_static {
         "src/util",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -5305,9 +5343,10 @@ cc_library_static {
         "src/vulkan/wsi",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -5468,9 +5507,10 @@ cc_library_static {
         "src/vulkan/wsi",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -5631,9 +5671,10 @@ cc_library_static {
         "src/vulkan/wsi",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -5794,9 +5835,10 @@ cc_library_static {
         "src/vulkan/wsi",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -5957,9 +5999,10 @@ cc_library_static {
         "src/vulkan/wsi",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -6120,9 +6163,10 @@ cc_library_static {
         "src/vulkan/wsi",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -6330,9 +6374,10 @@ cc_library_static {
         "hwvulkan_headers",
         "libdrm_headers",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -6462,9 +6507,10 @@ cc_library_static {
         "src/intel/ds",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -6475,9 +6521,10 @@ cc_library_static {
         "-Wno-error",
         "-Wno-non-virtual-dtor",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -6600,9 +6647,10 @@ cc_library_static {
         "src/intel/decoder",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -6816,9 +6864,10 @@ cc_library_static {
         "src/intel/compiler",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -6951,9 +7000,10 @@ cc_library_static {
         "src/intel/genxml",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -7096,9 +7146,10 @@ cc_library_static {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -7428,9 +7479,10 @@ cc_library_static {
         "src/compiler/nir",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -7552,9 +7604,10 @@ cc_library_static {
         "src",
         "src/compiler",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -7755,9 +7808,10 @@ cc_library_shared {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -7880,9 +7934,10 @@ cc_library_static {
         "src/mapi",
         "src/mesa",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -8236,9 +8291,10 @@ cc_library_static {
         "src/mesa/main",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -8363,9 +8419,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -8376,9 +8433,10 @@ cc_library_static {
         "-Wno-error",
         "-Wno-non-virtual-dtor",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -8594,9 +8652,10 @@ cc_library_static {
         "src/intel/compiler/elk",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -8729,9 +8788,10 @@ cc_library_static {
         "src/intel/genxml",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -8853,9 +8913,10 @@ cc_library_static {
         "src/gallium/winsys/sw/wrapper",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -8977,9 +9038,10 @@ cc_library_static {
         "src/gallium/winsys/sw/null",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -9102,9 +9164,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -9226,9 +9289,10 @@ cc_library_static {
         "src/gallium/winsys/sw/dri",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -9351,9 +9415,10 @@ cc_library_static {
         "src/gallium/winsys/iris/drm",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -9493,9 +9558,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -9639,9 +9705,10 @@ cc_library_static {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -9785,9 +9852,10 @@ cc_library_static {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -9931,9 +9999,10 @@ cc_library_static {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -10077,9 +10146,10 @@ cc_library_static {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -10223,9 +10293,10 @@ cc_library_static {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -10369,9 +10440,10 @@ cc_library_static {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -10515,9 +10587,10 @@ cc_library_static {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -10686,9 +10759,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -10819,9 +10893,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -10964,9 +11039,10 @@ cc_library_static {
         "src/gallium/include",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -11247,9 +11323,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -11455,9 +11532,10 @@ cc_library_static {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -11588,9 +11666,10 @@ cc_library_static {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -11763,9 +11842,10 @@ cc_library_shared {
         "src/x11",
         "subprojects/perfetto/sdk",
     ],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }
@@ -11896,9 +11976,10 @@ cc_library_static {
         "subprojects/perfetto/sdk",
     ],
     header_libs: ["libdrm_headers"],
+    enabled: false,
     arch: {
-        x86: {
-            enabled: false,
+        x86_64: {
+            enabled: true,
         },
     },
 }

--- a/tests/mesa3d/desktop-intel/Android.bp
+++ b/tests/mesa3d/desktop-intel/Android.bp
@@ -31,7 +31,7 @@ license {
 }
 
 cc_binary {
-    name: "pps-producer_mesa3d_desktop_intel",
+    name: "mesa3d_desktop-intel_pps-producer",
     stem: "pps-producer",
     srcs: [
         "src/tool/pps/pps_datasource.cc",
@@ -3542,7 +3542,7 @@ cc_library_static {
 }
 
 cc_library_shared {
-    name: "libglapi_mesa3d_desktop_intel",
+    name: "mesa3d_desktop-intel_libglapi",
     stem: "libglapi",
     srcs: [
         "src/mapi/entry.c",
@@ -3690,7 +3690,7 @@ cc_library_shared {
 }
 
 cc_library_shared {
-    name: "libGLESv2_mesa3d_desktop_intel",
+    name: "mesa3d_desktop-intel_libGLESv2_mesa",
     stem: "libGLESv2_mesa",
     srcs: ["src/mapi/entry.c"],
     cflags: [
@@ -3800,7 +3800,7 @@ cc_library_shared {
     ],
     shared_libs: [
         "libdrm",
-        "libglapi_mesa3d_desktop_intel",
+        "mesa3d_desktop-intel_libglapi",
     ],
     static_libs: ["mesa3d_desktop-intel_src_c11_impl_libmesa_util_c11_a"],
     local_include_dirs: [
@@ -3820,7 +3820,7 @@ cc_library_shared {
 }
 
 cc_library_shared {
-    name: "libGLESv1_CM_mesa3d_desktop_intel",
+    name: "mesa3d_desktop-intel_libGLESv1_CM_mesa",
     stem: "libGLESv1_CM_mesa",
     srcs: ["src/mapi/entry.c"],
     cflags: [
@@ -3930,7 +3930,7 @@ cc_library_shared {
     ],
     shared_libs: [
         "libdrm",
-        "libglapi_mesa3d_desktop_intel",
+        "mesa3d_desktop-intel_libglapi",
     ],
     static_libs: ["mesa3d_desktop-intel_src_c11_impl_libmesa_util_c11_a"],
     local_include_dirs: [
@@ -3950,7 +3950,7 @@ cc_library_shared {
 }
 
 cc_library_shared {
-    name: "libvulkan_intel_mesa3d_desktop_intel",
+    name: "mesa3d_desktop-intel_libvulkan_intel",
     stem: "vulkan.intel",
     srcs: ["src/intel/vulkan/anv_gem.c"],
     cflags: [
@@ -7560,7 +7560,7 @@ cc_library_static {
 }
 
 cc_library_shared {
-    name: "libgallium_dri_mesa3d_desktop_intel",
+    name: "mesa3d_desktop-intel_libgallium_dri",
     stem: "libgallium_dri",
     srcs: ["src/gallium/targets/dri/dri_target.c"],
     cflags: [
@@ -7670,12 +7670,12 @@ cc_library_shared {
     shared_libs: [
         "libcutils",
         "libdrm",
-        "libglapi_mesa3d_desktop_intel",
         "libhardware",
         "liblog",
         "libnativewindow",
         "libsync",
         "libz",
+        "mesa3d_desktop-intel_libglapi",
     ],
     static_libs: [
         "mesa3d_desktop-intel_src_c11_impl_libmesa_util_c11_a",
@@ -11596,7 +11596,7 @@ cc_library_static {
 }
 
 cc_library_shared {
-    name: "libEGL_mesa3d_desktop_intel",
+    name: "mesa3d_desktop-intel_libEGL_mesa",
     stem: "libEGL_mesa",
     srcs: [
         "src/egl/drivers/dri2/egl_dri2.c",
@@ -11726,13 +11726,13 @@ cc_library_shared {
     shared_libs: [
         "libcutils",
         "libdrm",
-        "libgallium_dri_mesa3d_desktop_intel",
-        "libglapi_mesa3d_desktop_intel",
         "libhardware",
         "liblog",
         "libnativewindow",
         "libsync",
         "libz",
+        "mesa3d_desktop-intel_libgallium_dri",
+        "mesa3d_desktop-intel_libglapi",
     ],
     static_libs: [
         "mesa3d_desktop-intel_src_c11_impl_libmesa_util_c11_a",


### PR DESCRIPTION
We don't want to build the Intel GPU drivers on ARM, etc.