### PR TITLE
mesa: Pass through -Wl,--build-id=sha1

### DIFF
--- a/src/project/mesa3d_desktop_intel.rs
+++ b/src/project/mesa3d_desktop_intel.rs
@@ -265,8 +265,8 @@ impl Project for Mesa3DDesktopIntel {
             && (!inc.contains(&path_to_string(&subprojects))
                 || inc.contains(&path_to_string(&subprojects.join("perfetto"))))
     }
-    fn filter_link_flag(&self, _flag: &str) -> bool {
-        false
+    fn filter_link_flag(&self, flag: &str) -> bool {
+        flag == "-Wl,--build-id=sha1"
     }
     fn filter_gen_header(&self, _header: &Path) -> bool {
         false

--- a/tests/mesa3d/desktop-intel/Android.bp
+++ b/tests/mesa3d/desktop-intel/Android.bp
@@ -3811,6 +3811,7 @@ cc_library_shared {
         "-Wno-error",
         "-Wno-non-virtual-dtor",
     ],
+    ldflags: ["-Wl,--build-id=sha1"],
     shared_libs: [
         "libcutils",
         "libdrm",
@@ -9510,6 +9511,7 @@ cc_library_shared {
         "-Wno-error",
         "-Wno-non-virtual-dtor",
     ],
+    ldflags: ["-Wl,--build-id=sha1"],
     shared_libs: [
         "libcutils",
         "libdrm",


### PR DESCRIPTION
The drivers expect their binaries to have a `.note.gnu.build-id` section containing a SHA1 hash. Otherwise they will fail to initialize.