### PR TITLE
mesa3d/desktop-intel: Set `soc_specific: true` on all targets

### DIFF
--- a/src/project/mesa3d_desktop_intel.rs
+++ b/src/project/mesa3d_desktop_intel.rs
@@ -150,6 +150,7 @@ impl Project for Mesa3DDesktopIntel {
                 r#"
 cc_defaults {{
     name: "{RAW_DEFAULTS}",
+    soc_specific: true,
     enabled: false,
     arch: {{
         x86_64: {{
@@ -168,23 +169,6 @@ cc_defaults {{
     }
 
     fn extend_module(&self, target: &Path, module: SoongModule) -> SoongModule {
-        let is_soc_specific = |module: SoongModule| -> SoongModule {
-            for lib in [
-                "libgallium_dri.so",
-                "libvulkan_intel.so",
-                "libGLESv1_CM_mesa.so.1.1.0",
-                "libGLESv2_mesa.so.2.0.0",
-                "libEGL_mesa.so.1.0.0",
-                "pps-producer",
-            ] {
-                if target.ends_with(lib) {
-                    return module.add_prop("soc_specific", SoongProp::Bool(true));
-                }
-            }
-            module
-        };
-        let module = is_soc_specific(module);
-
         let relative_install = |module: SoongModule| -> SoongModule {
             for lib in [
                 "libGLESv1_CM_mesa.so.1.1.0",

--- a/tests/mesa3d/desktop-intel/Android.bp
+++ b/tests/mesa3d/desktop-intel/Android.bp
@@ -83,7 +83,6 @@ cc_binary {
         "src/tool/pps",
         "subprojects/perfetto/sdk",
     ],
-    soc_specific: true,
     defaults: ["mesa3d-desktop-intel-defaults"],
 }
 
@@ -781,7 +780,6 @@ cc_library_shared {
         "src/mapi",
         "src/mapi/es2api",
     ],
-    soc_specific: true,
     relative_install_path: "egl",
     defaults: ["mesa3d-desktop-intel-defaults"],
 }
@@ -876,7 +874,6 @@ cc_library_shared {
         "src/mesa",
         "subprojects/perfetto/sdk",
     ],
-    soc_specific: true,
     defaults: ["mesa3d-desktop-intel-defaults"],
 }
 
@@ -2495,7 +2492,6 @@ cc_library_shared {
         "src/mapi",
         "src/mapi/es1api",
     ],
-    soc_specific: true,
     relative_install_path: "egl",
     defaults: ["mesa3d-desktop-intel-defaults"],
 }
@@ -2600,7 +2596,6 @@ cc_library_shared {
         "src/vulkan/wsi",
         "subprojects/perfetto/sdk",
     ],
-    soc_specific: true,
     relative_install_path: "hw",
     defaults: ["mesa3d-desktop-intel-defaults"],
 }
@@ -3360,7 +3355,6 @@ cc_library_shared {
         "src/x11",
         "subprojects/perfetto/sdk",
     ],
-    soc_specific: true,
     relative_install_path: "egl",
     header_libs: ["libnativebase_headers"],
     defaults: ["mesa3d-desktop-intel-defaults"],
@@ -3502,6 +3496,7 @@ cc_defaults {
 
 cc_defaults {
     name: "mesa3d-desktop-intel-raw-defaults",
+    soc_specific: true,
     enabled: false,
     arch: {
         x86_64: {


### PR DESCRIPTION
This was requested in Google bug 424615840 in order to begin enforcing a rule that vendor modules only link against vendor or vendor_available modules.

**FIXME**: Not to be landed yet. Currently breaks the build due to

```
vendor/google/graphics/mesa3d/desktop-intel/src/intel/dev/intel_debug.h:165:10: fatal error: 'log/log.h' file not found
  165 | #include <log/log.h>
      |          ^~~~~~~~~~~
6 warnings and 1 error generated.
```