### PR TITLE
mesa3d/desktop-intel: Drop `-Dgallium-xa=...`

### DIFF
--- a/tests/mesa3d/desktop-intel/build_mesa_clc.sh
+++ b/tests/mesa3d/desktop-intel/build_mesa_clc.sh
@@ -16,7 +16,6 @@ meson setup \
     -Dgallium-drivers= \
     -Dgallium-rusticl=false \
     -Dgallium-va=auto \
-    -Dgallium-xa=disabled \
     -Dbuildtype=release \
     -Dmesa-clc=enabled \
     -Dinstall-mesa-clc=true \

--- a/tests/mesa3d/desktop-intel/gen-ninja.sh
+++ b/tests/mesa3d/desktop-intel/gen-ninja.sh
@@ -38,7 +38,6 @@ meson setup \
     -Dgallium-drivers=iris \
     -Dgallium-rusticl=false \
     -Dgallium-va=disabled \
-    -Dgallium-xa=disabled \
     -Dbuildtype=release \
     -Dmesa-clc=system \
     -Dintel-rt=enabled \


### PR DESCRIPTION
It is off by default and the option has been removed in upstream Mesa, so let's remove it from our build configuration.