### PR TITLE
fix meson version for mesa

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -35,8 +35,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          sudo apt install ninja-build meson-1.5
-          meson --version
+          sudo apt install ninja-build
       - name: Setup environement variables
         shell: bash
         run: |

--- a/tests/mesa3d/desktop-intel/checkout.sh
+++ b/tests/mesa3d/desktop-intel/checkout.sh
@@ -10,7 +10,7 @@ bash "${SCRIPT_DIR}/../../../utils/checkout.sh" https://gitlab.freedesktop.org/m
 
 MAJOR_VERSION=17
 sudo apt install \
-     meson \
+     meson-1.5 \
      libclang-${MAJOR_VERSION}-dev \
      libclang-cpp${MAJOR_VERSION}{,-dev} \
      libclc-${MAJOR_VERSION}{,-dev} \

--- a/tests/mesa3d/desktop-panvk/checkout.sh
+++ b/tests/mesa3d/desktop-panvk/checkout.sh
@@ -10,7 +10,7 @@ bash "${SCRIPT_DIR}/../../../utils/checkout.sh" https://gitlab.freedesktop.org/z
 
 MAJOR_VERSION=18
 sudo apt install \
-     meson \
+     meson-1.5 \
      libclang-${MAJOR_VERSION}-dev \
      libclang-cpp${MAJOR_VERSION}{,-dev} \
      libclc-${MAJOR_VERSION}{,-dev} \


### PR DESCRIPTION
https://github.com/rjodinchr/ninja-to-soong/pull/199 tried to fix the mesa version by installing it in the github action, but it ends up being reverted by the install happening in checkout.sh in mesa projects.

Revert the github action, and update the checkout.sh scripts in mesa.