### PR TITLE
Wildcardize later in the flow

### DIFF
--- a/src/soong_module_generator.rs
+++ b/src/soong_module_generator.rs
@@ -277,11 +277,12 @@ where
                 SoongProp::Str(path_to_string(strip_prefix(vs, &self.src_path))),
             );
         }
+        let mut srcs_prop = SoongNamedProp::new("srcs", SoongProp::VecStr(sources));
         if ctx.wildcardize_paths {
-            sources = wildcardize_paths(sources, &self.src_path);
+            srcs_prop.enable_wildcard(&self.src_path)?;
         }
         module = module
-            .add_prop("srcs", SoongProp::VecStr(sources))
+            .add_named_prop(srcs_prop)
             .add_prop("cflags", SoongProp::VecStr(cflags))
             .add_prop("ldflags", SoongProp::VecStr(link_flags))
             .add_prop("shared_libs", SoongProp::VecStr(shared_libs))


### PR DESCRIPTION
The goal is to make sure that generated files exist when wildcarding.

Fix #219