### PR TITLE
Use -Dandroid-libbacktrace=disabled instead

### DIFF
--- a/src/project/mesa3d_desktop_intel.rs
+++ b/src/project/mesa3d_desktop_intel.rs
@@ -297,9 +297,6 @@ soong_namespace {
     fn filter_cflag(&self, cflag: &str) -> bool {
         cflag == "-mclflushopt"
     }
-    fn filter_define(&self, define: &str) -> bool {
-        define != "WITH_LIBBACKTRACE" // b/120606663
-    }
     fn filter_include(&self, include: &Path) -> bool {
         let inc = path_to_string(include);
         !include.ends_with("android_stub")
@@ -310,9 +307,6 @@ soong_namespace {
     }
     fn filter_gen_header(&self, _header: &Path) -> bool {
         false
-    }
-    fn filter_lib(&self, lib: &str) -> bool {
-        !lib.contains("libbacktrace")
     }
     fn filter_target(&self, target: &Path) -> bool {
         let file_name = file_name(target);

--- a/src/project/mesa3d_desktop_panvk.rs
+++ b/src/project/mesa3d_desktop_panvk.rs
@@ -183,9 +183,6 @@ soong_namespace {
     fn filter_cflag(&self, _cflag: &str) -> bool {
         false
     }
-    fn filter_define(&self, define: &str) -> bool {
-        define != "WITH_LIBBACKTRACE" // b/120606663
-    }
     fn filter_include(&self, include: &Path) -> bool {
         let inc = path_to_string(include);
         let subprojects = self.src_path.join("subprojects");
@@ -197,9 +194,6 @@ soong_namespace {
     }
     fn filter_gen_header(&self, _header: &Path) -> bool {
         false
-    }
-    fn filter_lib(&self, lib: &str) -> bool {
-        !lib.contains("libbacktrace")
     }
     fn filter_target(&self, target: &Path) -> bool {
         let file_name = file_name(target);

--- a/tests/mesa3d/desktop-intel/gen-ninja.sh
+++ b/tests/mesa3d/desktop-intel/gen-ninja.sh
@@ -23,6 +23,7 @@ meson setup \
     --cross-file "${AOSP_X86_64}" \
     --libdir lib64 \
     --sysconfdir=/system/vendor/etc \
+    -Dandroid-libbacktrace=disabled \
     -Dallow-fallback-for=libdrm \
     -Dllvm=disabled \
     -Dglx=disabled \

--- a/tests/mesa3d/desktop-panvk/gen-ninja.sh
+++ b/tests/mesa3d/desktop-panvk/gen-ninja.sh
@@ -22,6 +22,7 @@ meson setup \
     --cross-file "${AOSP_AARCH64}" \
     --libdir lib64 \
     --sysconfdir=/system/vendor/etc \
+    -Dandroid-libbacktrace=disabled \
     -Dllvm=disabled \
     -Degl=disabled \
     -Dplatform-sdk-version=${ANDROID_PLATFORM} \


### PR DESCRIPTION
This drops more custom codes from the projects.