### PR TITLE
filter_default: ret err when prop is not in self

### DIFF
--- a/src/project/mesa3d_desktop_panvk.rs
+++ b/src/project/mesa3d_desktop_panvk.rs
@@ -107,12 +107,10 @@ impl Project for Mesa3DDesktopPanVK {
 
         let default_module = SoongModule::new("cc_defaults")
             .add_prop("name", SoongProp::Str(String::from(DEFAULTS)))
-            .add_prop("soc_specific", SoongProp::Bool(true))
-            .add_prop(
-                "header_libs",
-                SoongProp::VecStr(vec!["libdrm_headers".to_string()]),
-            )
-            .add_props(package.get_props("mesa3d_desktop-panvk_pps-producer", vec!["cflags"])?);
+            .add_props(package.get_props(
+                "mesa3d_desktop-panvk_pps-producer",
+                vec!["soc_specific", "header_libs", "cflags"],
+            )?);
 
         package
             .add_module(default_module)
@@ -127,13 +125,9 @@ soong_namespace {
 
     fn extend_module(&self, target: &Path, module: SoongModule) -> Result<SoongModule, String> {
         let module = if target.ends_with("libvulkan_panfrost.so") {
-            module.add_prop("relative_install_path", SoongProp::Str(String::from("hw")))
-        } else {
             module
-        };
-
-        let module = if target.ends_with("libvulkan_panfrost.so") {
-            module.add_prop("afdo", SoongProp::Bool(true))
+                .add_prop("relative_install_path", SoongProp::Str(String::from("hw")))
+                .add_prop("afdo", SoongProp::Bool(true))
         } else {
             module
         };
@@ -157,15 +151,19 @@ soong_namespace {
             libs.push("libz");
         }
         if !["libperfetto.a"].contains(&file_name(target).as_str()) {
-            module.add_prop("defaults", SoongProp::VecStr(vec![String::from(DEFAULTS)]))
-        } else {
             module
-                .add_prop("soc_specific", SoongProp::Bool(true))
+                .add_prop("defaults", SoongProp::VecStr(vec![String::from(DEFAULTS)]))
                 .add_prop(
                     "header_libs",
-                    SoongProp::VecStr(vec!["liblog_headers".to_string()]),
+                    SoongProp::VecStr(vec!["libdrm_headers".to_string()]),
                 )
+        } else {
+            module.add_prop(
+                "header_libs",
+                SoongProp::VecStr(vec!["liblog_headers".to_string()]),
+            )
         }
+        .add_prop("soc_specific", SoongProp::Bool(true))
         .extend_prop("cflags", cflags)?
         .extend_prop("shared_libs", libs)
     }

--- a/src/soong_module.rs
+++ b/src/soong_module.rs
@@ -270,16 +270,27 @@ impl SoongModule {
             SoongProp::Str(name) => name,
             _ => return error!("Unexpected SoongProp 'name' in {default:#?}"),
         };
+        let find_prop_idx = |name: &str, props: &Vec<SoongNamedProp>| {
+            for idx in 0..props.len() {
+                if props[idx].name == name {
+                    return Some(idx);
+                }
+            }
+            return None;
+        };
         for default_prop in &default.props {
             let name = &default_prop.name;
-            for idx in 0..self.props.len() {
-                if &self.props[idx].name == name && name != "name" {
-                    let self_prop = self.props.remove(idx);
-                    self.props.insert(
-                        idx,
-                        self_prop.filter_default(default_prop.get_prop(), &my_name)?,
-                    );
-                }
+            if name == "name" {
+                continue;
+            }
+            if let Some(idx) = find_prop_idx(name, &self.props) {
+                let self_prop = self.props.remove(idx);
+                self.props.insert(
+                    idx,
+                    self_prop.filter_default(default_prop.get_prop(), &my_name)?,
+                );
+            } else {
+                return error!("Could not find prop '{name}' in module properties:\n{self:#?}");
             }
         }
         Ok(())

--- a/tests/mesa3d/desktop-panvk/Android.bp.n2s
+++ b/tests/mesa3d/desktop-panvk/Android.bp.n2s
@@ -120,8 +120,8 @@ cc_library_static {
         "-Wno-unused-parameter",
     ],
     local_include_dirs: ["subprojects/perfetto"],
-    soc_specific: true,
     header_libs: ["liblog_headers"],
+    soc_specific: true,
 }
 
 cc_library_static {


### PR DESCRIPTION
Every properties in default should be found inside module using defaults. 
Fix default usage in panvk

